### PR TITLE
Update GitHub Actions for Node 24 runtime

### DIFF
--- a/.github/workflows/code_changes.yaml
+++ b/.github/workflows/code_changes.yaml
@@ -15,7 +15,7 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - name: Check formatting with ruff
           run: |
             pip install ruff
@@ -23,12 +23,12 @@ jobs:
   Test:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - name: Install uv
-          uses: astral-sh/setup-uv@v5
+          uses: astral-sh/setup-uv@v8.1.0
 
         - name: Set up Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v6
           with:
               python-version: '3.11'
         - name: Install dependencies
@@ -40,7 +40,7 @@ jobs:
             make targets &&
             make data
         - name: Save calibration log
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
             name: calibration_log.csv
             path: calibration_log.csv

--- a/.github/workflows/pr_code_changes.yaml
+++ b/.github/workflows/pr_code_changes.yaml
@@ -15,7 +15,7 @@ jobs:
   Lint:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - name: Check formatting with ruff
           run: |
             pip install ruff
@@ -23,12 +23,12 @@ jobs:
   Test:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - name: Install uv
-          uses: astral-sh/setup-uv@v5
+          uses: astral-sh/setup-uv@v8.1.0
 
         - name: Set up Python
-          uses: actions/setup-python@v2
+          uses: actions/setup-python@v6
           with:
               python-version: '3.11'
         - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
         - name: Build data
           run: make data
         - name: Save calibration log
-          uses: actions/upload-artifact@v4
+          uses: actions/upload-artifact@v7
           with:
             name: calibration_log.csv
             path: calibration_log.csv


### PR DESCRIPTION
Updates GitHub Actions workflow action versions to releases that run on Node.js 24, removing Node.js 20 JavaScript action deprecation warnings before GitHub-hosted runners switch defaults on June 2, 2026.

This is a mechanical workflow-only change from an org-wide scan. It also updates older checkout/setup/action versions that still advertised Node.js 12 or 16 runtimes where a Node.js 24 successor is available.